### PR TITLE
added vehicle specs interface

### DIFF
--- a/bimmer_connected/vehicle.py
+++ b/bimmer_connected/vehicle.py
@@ -1,11 +1,25 @@
 """Models state and remote services of one vehicle."""
 
+import json
 from bimmer_connected.state import VehicleState
 from bimmer_connected.remote_services import RemoteServices
 
 # List of known attributes of a vehicle
-ATTRIBUTES = ['series', 'vin', 'basicType', 'brand', 'hasRex', 'doorCount', 'steering', 'hasSunRoof', 'bodyType',
-              'dcOnly', 'driveTrain', 'hasNavi', 'modelName']
+VEHICLE_ATTRIBUTES = [
+    'series', 'vin', 'basicType', 'brand', 'hasRex', 'doorCount', 'steering', 'hasSunRoof',
+    'bodyType',
+    'dcOnly', 'driveTrain', 'hasNavi', 'modelName']
+
+# List of known attributes of a vehicle spec
+VEHICLE_SPEC_ATTRIBUES = [
+    "TANK_CAPACITY", "PERFORMANCE_TOP_SPEED", "PERFORMANCE_ACCELERATION", "WEIGHT_UNLADEN",
+    "WEIGHT_MAX", "WEIGHT_PERMITTED_LOAD", "WEIGHT_PERMITTED_LOAD_FRONT", "WEIGHT_PERMITTED_LOAD_REAR",
+    "ENGINE_CYLINDERS", "ENGINE_VALVES", "ENGINE_STROKE", "ENGINE_BORE", "ENGINE_OUTPUT_MAX_KW",
+    "ENGINE_OUTPUT_MAX_HP", "ENGINE_SPEED_OUTPUT_MAX", "ENGINE_TORQUE_MAX",
+    "ENGINE_SPEED_TORQUE_MAX", "ENGINE_COMPRESSION",
+]
+
+VEHICLE_SPECS_URL = '{server}/api/vehicle/specs/v1/{vin}'
 
 
 class ConnectedDriveVehicle(object):  # pylint: disable=too-few-public-methods
@@ -17,11 +31,37 @@ class ConnectedDriveVehicle(object):  # pylint: disable=too-few-public-methods
         self.attributes = attributes
         self.state = VehicleState(account, self)
         self.remote_services = RemoteServices(account, self)
+        self.specs = VehicleSpecs(account, self)
 
     def update_state(self):
         """Update the state of a vehicle."""
         self.state.update_data()
+        self.specs.update_data()
 
+    def __getattr__(self, item):
+        """In the first version: just get the attributes from the dict.
+
+        In a later version we might parse the attributes to provide a more advanced API.
+        """
+        return self.attributes[item]
+
+
+class VehicleSpecs(object):
+
+    def __init__(self, account, vehicle):
+        self._account = account
+        self._vehicle = vehicle
+        self.attributes = None
+
+    def update_data(self):
+        url = VEHICLE_SPECS_URL.format(server=self._account.server_url, vin=self._vehicle.vin)
+
+        response = self._account.send_request(url)
+
+        self.attributes = dict()
+        for attribute in json.loads(response.text):
+            self.attributes[attribute['key']]=attribute['value']
+    
     def __getattr__(self, item):
         """In the first version: just get the attributes from the dict.
 

--- a/bimmer_connected/vehicle.py
+++ b/bimmer_connected/vehicle.py
@@ -1,6 +1,5 @@
 """Models state and remote services of one vehicle."""
 
-import json
 from bimmer_connected.state import VehicleState
 from bimmer_connected.remote_services import RemoteServices
 
@@ -62,7 +61,7 @@ class VehicleSpecs(object):  # pylint: disable=too-few-public-methods
         response = self._account.send_request(url)
 
         self.attributes = dict()
-        for attribute in json.loads(response.text):
+        for attribute in response.json():
             self.attributes[attribute['key']] = attribute['value']
 
     def __getattr__(self, item):

--- a/bimmer_connected/vehicle.py
+++ b/bimmer_connected/vehicle.py
@@ -70,4 +70,6 @@ class VehicleSpecs(object):  # pylint: disable=too-few-public-methods
 
         In a later version we might parse the attributes to provide a more advanced API.
         """
+        if self.attributes is None:
+            self.update_data()
         return self.attributes[item]

--- a/bimmer_connected/vehicle.py
+++ b/bimmer_connected/vehicle.py
@@ -46,22 +46,25 @@ class ConnectedDriveVehicle(object):  # pylint: disable=too-few-public-methods
         return self.attributes[item]
 
 
-class VehicleSpecs(object):
+class VehicleSpecs(object):  # pylint: disable=too-few-public-methods
+    """Get the specifications of the vehicle"""
 
     def __init__(self, account, vehicle):
+        """Constructor."""
         self._account = account
         self._vehicle = vehicle
         self.attributes = None
 
     def update_data(self):
+        """Fetch the specification from the server."""
         url = VEHICLE_SPECS_URL.format(server=self._account.server_url, vin=self._vehicle.vin)
 
         response = self._account.send_request(url)
 
         self.attributes = dict()
         for attribute in json.loads(response.text):
-            self.attributes[attribute['key']]=attribute['value']
-    
+            self.attributes[attribute['key']] = attribute['value']
+
     def __getattr__(self, item):
         """In the first version: just get the attributes from the dict.
 

--- a/status.py
+++ b/status.py
@@ -12,7 +12,7 @@ def main():
     logging.basicConfig(level=logging.DEBUG)
 
     parser = argparse.ArgumentParser()
-    parser.add_argument('-l', action='store_true', description='log the responses from the server')
+    parser.add_argument('-l', action='store_true')
     parser.add_argument('username')
     parser.add_argument('password')
     parser.add_argument('country')

--- a/status.py
+++ b/status.py
@@ -30,6 +30,8 @@ def main():
         print('mileage: {}'.format(vehicle.state.mileage))
         print('Response from the server:')
         print(json.dumps(vehicle.state.attributes, indent=4))
+        print('vehicle specs:')
+        print(json.dumps(vehicle.specs.attributes, indent=4))
 
 
 if __name__ == '__main__':

--- a/test/responses/G31_NBTevo/specs.json
+++ b/test/responses/G31_NBTevo/specs.json
@@ -1,0 +1,55 @@
+[ {
+  "key" : "TANK_CAPACITY",
+  "value" : "68.0"
+}, {
+  "key" : "PERFORMANCE_TOP_SPEED",
+  "value" : "250"
+}, {
+  "key" : "PERFORMANCE_ACCELERATION",
+  "value" : "6.3"
+}, {
+  "key" : "WEIGHT_UNLADEN",
+  "value" : "1770"
+}, {
+  "key" : "WEIGHT_MAX",
+  "value" : "2440"
+}, {
+  "key" : "WEIGHT_PERMITTED_LOAD",
+  "value" : "730"
+}, {
+  "key" : "WEIGHT_PERMITTED_LOAD_FRONT",
+  "value" : "1115"
+}, {
+  "key" : "WEIGHT_PERMITTED_LOAD_REAR",
+  "value" : "1425"
+}, {
+  "key" : "ENGINE_CYLINDERS",
+  "value" : "4"
+}, {
+  "key" : "ENGINE_VALVES",
+  "value" : "4"
+}, {
+  "key" : "ENGINE_STROKE",
+  "value" : "94.6"
+}, {
+  "key" : "ENGINE_BORE",
+  "value" : "82.0"
+}, {
+  "key" : "ENGINE_OUTPUT_MAX_KW",
+  "value" : "185"
+}, {
+  "key" : "ENGINE_OUTPUT_MAX_HP",
+  "value" : "252"
+}, {
+  "key" : "ENGINE_SPEED_OUTPUT_MAX",
+  "value" : "5200-6500"
+}, {
+  "key" : "ENGINE_TORQUE_MAX",
+  "value" : "350"
+}, {
+  "key" : "ENGINE_SPEED_TORQUE_MAX",
+  "value" : "1450-4800"
+}, {
+  "key" : "ENGINE_COMPRESSION",
+  "value" : "10.2"
+} ]

--- a/test/test_specs.py
+++ b/test/test_specs.py
@@ -1,0 +1,30 @@
+"""Tests for VehicleSpecs."""
+
+import unittest
+from unittest import mock
+from test import TEST_COUNTRY, TEST_PASSWORD, TEST_USERNAME, BackendMock, G31_VIN
+from bimmer_connected import ConnectedDriveAccount
+
+
+class TestVehicleSpecs(unittest.TestCase):
+    """Tests for VehicleSpecs."""
+
+    def test_update_data_error(self):
+        """Test with server returning an error."""
+        backend_mock = BackendMock()
+        with mock.patch('bimmer_connected.requests', new=backend_mock):
+            account = ConnectedDriveAccount(TEST_USERNAME, TEST_PASSWORD, TEST_COUNTRY)
+            vehicle = account.get_vehicle(G31_VIN)
+            with self.assertRaises(IOError):
+                vehicle.update_state()
+
+    def test_update_data(self):
+        """Test with proper data."""
+        backend_mock = BackendMock()
+        backend_mock.add_response('.*/api/vehicle/specs/v1/{vin}'.format(vin=G31_VIN),
+                                  data_file='G31_NBTevo/specs.json')
+
+        with mock.patch('bimmer_connected.requests', new=backend_mock):
+            account = ConnectedDriveAccount(TEST_USERNAME, TEST_PASSWORD, TEST_COUNTRY)
+            vehicle = account.get_vehicle(G31_VIN)
+            self.assertAlmostEqual(68.0, float(vehicle.specs.TANK_CAPACITY))


### PR DESCRIPTION
With the "specs" interface you can get your vehicle specifications.

This is the additional output when running "status.py" now:
```json
vehicle specs:
{
    "ENGINE_COMPRESSION": "10.2",
    "ENGINE_BORE": "82.0",
    "TANK_CAPACITY": "68.0",
    "PERFORMANCE_TOP_SPEED": "250",
    "WEIGHT_MAX": "2440",
    "ENGINE_TORQUE_MAX": "350",
    "WEIGHT_PERMITTED_LOAD_REAR": "1425",
    "WEIGHT_PERMITTED_LOAD_FRONT": "1115",
    "ENGINE_CYLINDERS": "4",
    "ENGINE_OUTPUT_MAX_KW": "185",
    "PERFORMANCE_ACCELERATION": "6.3",
    "ENGINE_SPEED_TORQUE_MAX": "1450-4800",
    "ENGINE_SPEED_OUTPUT_MAX": "5200-6500",
    "ENGINE_STROKE": "94.6",
    "WEIGHT_PERMITTED_LOAD": "730",
    "ENGINE_OUTPUT_MAX_HP": "252",
    "WEIGHT_UNLADEN": "1770",
    "ENGINE_VALVES": "4"
}
```
My use case for this: show remaining fuel in % rather than liters. So I need to know how big the tank is.

@gerard33 What do you think?
