### PR TITLE
Changed API for remote services

### DIFF
--- a/bimmer_connected/account.py
+++ b/bimmer_connected/account.py
@@ -14,6 +14,7 @@ import logging
 import urllib
 import os
 from threading import Lock
+from typing import Callable
 import requests
 
 from bimmer_connected.country_selector import CountrySelector
@@ -48,6 +49,7 @@ class ConnectedDriveAccount(object):  # pylint: disable=too-many-instance-attrib
         #: list of vehicles associated with this account.
         self.vehicles = []
         self._lock = Lock()
+        self._update_listeners = []
 
         self._get_vehicles()
 
@@ -173,6 +175,15 @@ class ConnectedDriveAccount(object):  # pylint: disable=too-many-instance-attrib
         return None
 
     def update_vehicle_states(self) -> None:
-        """Update the state of all vehicles."""
+        """Update the state of all vehicles.
+
+        Notify all listeners of the vehicle state update.
+        """
         for car in self.vehicles:
             car.update_state()
+        for listener in self._update_listeners:
+            listener()
+
+    def add_update_listener(self, listener: Callable) -> None:
+        """Add a listener for state updates."""
+        self._update_listeners.append(listener)

--- a/bimmer_connected/const.py
+++ b/bimmer_connected/const.py
@@ -1,7 +1,7 @@
 """Version numbers of bimmer_connected."""
 MAJOR_VERSION = 0
-MINOR_VERSION = 3
-PATCH_VERSION = '1_dev'
+MINOR_VERSION = 4
+PATCH_VERSION = '0_dev'
 
 __short_version__ = '{}.{}'.format(MAJOR_VERSION, MINOR_VERSION)
 __version__ = '{}.{}'.format(__short_version__, PATCH_VERSION)

--- a/bimmer_connected/remote_services.py
+++ b/bimmer_connected/remote_services.py
@@ -35,6 +35,8 @@ class _Services(Enum):
     REMOTE_DOOR_LOCK = 'RDL'
     REMOTE_DOOR_UNLOCK = 'RDU'
     REMOTE_SERVICE_STATUS = 'state/execution'
+    REMOTE_HORN = 'RHB'
+    REMOTE_AIR_CONDITIONING = 'RCN'
 
 
 class RemoteServiceStatus(object):  # pylint: disable=too-few-public-methods
@@ -68,7 +70,7 @@ class RemoteServices(object):
         self._account = account
         self._vehicle = vehicle
 
-    def trigger_remote_light_flash(self):
+    def trigger_remote_light_flash(self) -> RemoteServiceStatus:
         """Trigger the vehicle to flash its headlights.
 
         A state update is NOT triggered after this, as the vehicle state is unchanged.
@@ -78,7 +80,7 @@ class RemoteServices(object):
         self._trigger_remote_service(_Services.REMOTE_LIGHT_FLASH, post=True)
         return self._block_until_done()
 
-    def trigger_remote_door_lock(self):
+    def trigger_remote_door_lock(self) -> RemoteServiceStatus:
         """Trigger the vehicle to lock its doors.
 
         A state update is triggered after this, as the lock state of the vehicle changes.
@@ -90,7 +92,7 @@ class RemoteServices(object):
         self._trigger_state_update()
         return result
 
-    def trigger_remote_door_unlock(self):
+    def trigger_remote_door_unlock(self) -> RemoteServiceStatus:
         """Trigger the vehicle to unlock its doors.
 
         A state update is triggered after this, as the lock state of the vehicle changes.
@@ -101,6 +103,26 @@ class RemoteServices(object):
         result = self._block_until_done()
         self._trigger_state_update()
         return result
+
+    def trigger_remote_horn(self) -> RemoteServiceStatus:
+        """Trigger the vehicle to sound its horn.
+
+        A state update is NOT triggered after this, as the vehicle state is unchanged.
+        """
+        _LOGGER.debug('Triggering remote light flash')
+        # needs to be called via POST, GET is not working
+        self._trigger_remote_service(_Services.REMOTE_HORN, post=True)
+        return self._block_until_done()
+
+    def trigger_remote_air_conditioning(self) -> RemoteServiceStatus:
+        """Trigger the vehicle to sound its horn.
+
+        A state update is NOT triggered after this, as the vehicle state is unchanged.
+        """
+        _LOGGER.debug('Triggering remote light flash')
+        # needs to be called via POST, GET is not working
+        self._trigger_remote_service(_Services.REMOTE_AIR_CONDITIONING, post=True)
+        return self._block_until_done()
 
     def _trigger_remote_service(self, service_id: _Services, post=False) -> requests.Response:
         """Trigger a generic remote service.
@@ -128,7 +150,7 @@ class RemoteServices(object):
             _LOGGER.debug('current state if remote service is: %s', status.state.value)
             time.sleep(_POLLING_CYCLE)
 
-    def _get_remote_service_status(self):
+    def _get_remote_service_status(self) -> RemoteServiceStatus:
         """The the execution status of the last remote service that was triggered.
 
         As the status changes over time, you probably need to poll this.

--- a/bimmer_connected/remote_services.py
+++ b/bimmer_connected/remote_services.py
@@ -144,12 +144,12 @@ class RemoteServices(object):
         fail_after = datetime.datetime.now() + datetime.timedelta(seconds=_POLLING_TIMEOUT)
         while True:
             status = self._get_remote_service_status()
+            _LOGGER.debug('current state if remote service is: %s', status.state.value)
             if status.state not in [ExecutionState.PENDING, ExecutionState.DELIVERED]:
                 return status
             if datetime.datetime.now() > fail_after:
                 raise IOError(
                     'Timeout on getting final answer from server. Current state: {}'.format(status.state.value))
-            _LOGGER.debug('current state if remote service is: %s', status.state.value)
             time.sleep(_POLLING_CYCLE)
 
     def _get_remote_service_status(self) -> RemoteServiceStatus:

--- a/bimmer_connected/remote_services.py
+++ b/bimmer_connected/remote_services.py
@@ -3,8 +3,8 @@
 from enum import Enum
 import datetime
 import logging
-import requests
 import time
+import requests
 from bimmer_connected.const import REMOTE_SERVICE_URL
 
 
@@ -128,4 +128,3 @@ class RemoteServices(object):
             _LOGGER.debug(response.headers)
             _LOGGER.debug(response.text)
             raise
-

--- a/bimmer_connected/remote_services.py
+++ b/bimmer_connected/remote_services.py
@@ -95,6 +95,7 @@ class RemoteServices(object):
         As the status changes over time, you probably need to poll this.
         Recommended polling time is AT LEAST one second as the reaction is sometimes quite slow.
         """
+        _LOGGER.debug('getting remote service status')
         response = self._trigger_remote_service(_Services.REMOTE_SERVICE_STATUS)
         try:
             json_result = response.json()

--- a/bimmer_connected/remote_services.py
+++ b/bimmer_connected/remote_services.py
@@ -109,6 +109,7 @@ class RemoteServices(object):
             if datetime.datetime.now() > fail_after:
                 raise IOError(
                     'Timeout on getting final answer from server. Current state: {}'.format(status.state.value))
+            _LOGGER.debug('current state if remote service is: %s', status.state.value)
             time.sleep(_POLLING_CYCLE)
 
     def _get_remote_service_status(self):

--- a/bimmer_connected/remote_services.py
+++ b/bimmer_connected/remote_services.py
@@ -122,7 +122,9 @@ class RemoteServices(object):
         _LOGGER.debug('Triggering remote light flash')
         # needs to be called via POST, GET is not working
         self._trigger_remote_service(_Services.REMOTE_AIR_CONDITIONING, post=True)
-        return self._block_until_done()
+        result = self._block_until_done()
+        self._trigger_state_update()
+        return result
 
     def _trigger_remote_service(self, service_id: _Services, post=False) -> requests.Response:
         """Trigger a generic remote service.

--- a/bimmer_connected/vehicle.py
+++ b/bimmer_connected/vehicle.py
@@ -54,6 +54,11 @@ class ConnectedDriveVehicle(object):  # pylint: disable=too-few-public-methods
         """Get the type of drive train of the vehicle."""
         return DriveTrainType(self.attributes['driveTrain'])
 
+    @property
+    def name(self):
+        """Get the name of the vehicle."""
+        return self.attributes['modelName']
+
     def __getattr__(self, item):
         """In the first version: just get the attributes from the dict.
 
@@ -85,11 +90,6 @@ class VehicleSpecs(object):  # pylint: disable=too-few-public-methods
             self.attributes = dict()
             for attribute in response.json():
                 self.attributes[attribute['key']] = attribute['value']
-
-    @property
-    def name(self):
-        """Get the name of the vehicle."""
-        return self.attributes['modelName']
 
     def __getattr__(self, item):
         """In the first version: just get the attributes from the dict.

--- a/bimmer_connected/vehicle.py
+++ b/bimmer_connected/vehicle.py
@@ -86,8 +86,9 @@ class VehicleSpecs(object):  # pylint: disable=too-few-public-methods
             for attribute in response.json():
                 self.attributes[attribute['key']] = attribute['value']
 
-    @@property
+    @property
     def name(self):
+        """Get the name of the vehicle."""
         return self.attributes['modelName']
 
     def __getattr__(self, item):

--- a/bimmer_connected/vehicle.py
+++ b/bimmer_connected/vehicle.py
@@ -77,13 +77,14 @@ class VehicleSpecs(object):  # pylint: disable=too-few-public-methods
 
     def update_data(self):
         """Fetch the specification from the server."""
-        url = VEHICLE_SPECS_URL.format(server=self._account.server_url, vin=self._vehicle.vin)
+        if self.attributes is None:
+            url = VEHICLE_SPECS_URL.format(server=self._account.server_url, vin=self._vehicle.vin)
 
-        response = self._account.send_request(url)
+            response = self._account.send_request(url)
 
-        self.attributes = dict()
-        for attribute in response.json():
-            self.attributes[attribute['key']] = attribute['value']
+            self.attributes = dict()
+            for attribute in response.json():
+                self.attributes[attribute['key']] = attribute['value']
 
     def __getattr__(self, item):
         """In the first version: just get the attributes from the dict.

--- a/bimmer_connected/vehicle.py
+++ b/bimmer_connected/vehicle.py
@@ -86,6 +86,10 @@ class VehicleSpecs(object):  # pylint: disable=too-few-public-methods
             for attribute in response.json():
                 self.attributes[attribute['key']] = attribute['value']
 
+    @@property
+    def name(self):
+        return self.attributes['modelName']
+
     def __getattr__(self, item):
         """In the first version: just get the attributes from the dict.
 

--- a/remote_light_flash.py
+++ b/remote_light_flash.py
@@ -23,10 +23,7 @@ def main():
     vehicle = account.get_vehicle(args.vin)
 
     status = vehicle.remote_services.trigger_remote_light_flash()
-    while status.state != ExecutionState.EXECUTED:
-        status = vehicle.remote_services.get_remote_service_status()
-        print(status.state)
-        time.sleep(1)
+    print(status.state)
 
 
 if __name__ == '__main__':

--- a/remote_light_flash.py
+++ b/remote_light_flash.py
@@ -3,9 +3,7 @@
 
 import argparse
 import logging
-import time
 from bimmer_connected.account import ConnectedDriveAccount
-from bimmer_connected.remote_services import ExecutionState
 
 
 def main():

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -3,6 +3,7 @@
 import re
 import os
 import json
+from typing import List
 
 RESPONSE_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'responses')
 
@@ -54,7 +55,7 @@ class BackendMock(object):
                          headers=_AUTH_RESPONSE_HEADERS,
                          status_code=302),
             MockResponse('.*/api/me/vehicles/v2',
-                         data_file='vehicles.json'),
+                         data_files=['vehicles.json']),
         ]
 
     def get(self, url: str, headers: dict = None, data: str = None, allow_redirects: bool = None) -> 'MockResponse':
@@ -67,10 +68,10 @@ class BackendMock(object):
         self.last_request = MockRequest(url, headers, data, request_type='GET', allow_redirects=allow_redirects)
         return self._find_response(url)
 
-    def add_response(self, regex: str, data: str = None, data_file: str = None, headers: dict = None, status_code=200) \
-            -> None:
+    def add_response(self, regex: str, data: str = None, data_files: List[str] = None,
+                     headers: dict = None, status_code=200) -> None:
         """Add a response to the backend."""
-        self.responses.append(MockResponse(regex, data, data_file, headers, status_code))
+        self.responses.append(MockResponse(regex, data, data_files, headers, status_code))
 
     def _find_response(self, url) -> 'MockResponse':
         """Find a proper response for a requested url."""
@@ -98,7 +99,7 @@ class MockResponse(object):
 
     # pylint: disable=too-many-arguments
 
-    def __init__(self, regex: str, data: str = None, data_file: str = None, headers: dict = None,
+    def __init__(self, regex: str, data: str = None, data_files: List[str] = None, headers: dict = None,
                  status_code: int = 200) -> None:
         """Constructor."""
         self.regex = re.compile(regex)
@@ -107,17 +108,19 @@ class MockResponse(object):
         if self.headers is None:
             self.headers = dict()
 
-        if data_file is not None:
-            with open(os.path.join(RESPONSE_DIR, data_file)) as response:
-                self._data = response.read()
+        if data_files is not None:
+            self._data = []
+            for data_file in data_files:
+                with open(os.path.join(RESPONSE_DIR, data_file)) as response:
+                    self._data.append(response.read())
         else:
-            self._data = data
+            self._data = [data]
 
     def json(self) -> dict:
         """Parse the text of the response as a jsons string."""
-        return json.loads(self._data)
+        return json.loads(self.text)
 
     @property
     def text(self) -> str:
         """Get the raw data from the response."""
-        return self._data
+        return self._data.pop(0)

--- a/test/test_remote_services.py
+++ b/test/test_remote_services.py
@@ -43,6 +43,8 @@ class TestRemoteServices(unittest.TestCase):
             ('RLF', 'trigger_remote_light_flash'),
             ('RDL', 'trigger_remote_door_lock'),
             ('RDU', 'trigger_remote_door_unlock'),
+            ('RCN', 'trigger_remote_air_conditioning'),
+            ('RHB', 'trigger_remote_horn')
         ]
 
         for service, call in services:

--- a/test/test_remote_services.py
+++ b/test/test_remote_services.py
@@ -37,6 +37,7 @@ class TestRemoteServices(unittest.TestCase):
     def test_trigger_remote_services(self):
         """Test executing a remote light flash."""
         remote_services._POLLING_CYCLE = 0
+        remote_services._UPDATE_AFTER_REMOTE_SERVICE_DELAY = 0
 
         services = [
             ('RLF', 'trigger_remote_light_flash'),
@@ -57,6 +58,12 @@ class TestRemoteServices(unittest.TestCase):
                         'G31_NBTevo/RLF_PENDING.json',
                         'G31_NBTevo/RLF_DELIVERED.json',
                         'G31_NBTevo/RLF_EXECUTED.json'])
+
+                backend_mock.add_response('.*/api/vehicle/dynamic/v1/{vin}'.format(vin=G31_VIN),
+                                          data_files=['G31_NBTevo/dynamic.json'])
+
+                backend_mock.add_response('.*/api/vehicle/specs/v1/{vin}'.format(vin=G31_VIN),
+                                          data_files=['G31_NBTevo/specs.json'])
 
                 account = ConnectedDriveAccount(TEST_USERNAME, TEST_PASSWORD, TEST_COUNTRY)
                 vehicle = account.get_vehicle(G31_VIN)

--- a/test/test_remote_services.py
+++ b/test/test_remote_services.py
@@ -56,8 +56,7 @@ class TestRemoteServices(unittest.TestCase):
                     data_files=[
                         'G31_NBTevo/RLF_PENDING.json',
                         'G31_NBTevo/RLF_DELIVERED.json',
-                        'G31_NBTevo/RLF_EXECUTED.json',
-                     ])
+                        'G31_NBTevo/RLF_EXECUTED.json'])
 
                 account = ConnectedDriveAccount(TEST_USERNAME, TEST_PASSWORD, TEST_COUNTRY)
                 vehicle = account.get_vehicle(G31_VIN)

--- a/test/test_remote_services.py
+++ b/test/test_remote_services.py
@@ -6,6 +6,7 @@ from test import BackendMock, TEST_USERNAME, TEST_PASSWORD, TEST_COUNTRY, G31_VI
 
 from bimmer_connected.account import ConnectedDriveAccount
 from bimmer_connected.remote_services import RemoteServiceStatus, ExecutionState
+from bimmer_connected import remote_services
 
 
 class TestRemoteServices(unittest.TestCase):
@@ -35,39 +36,47 @@ class TestRemoteServices(unittest.TestCase):
 
     def test_trigger_remote_services(self):
         """Test executing a remote light flash."""
-        backend_mock = BackendMock()
-        for service in ['RLF', 'RDU', 'RDL']:
-            backend_mock.add_response(r'.*/api/vehicle/remoteservices/v1/{vin}/{service}'.format(
-                vin=G31_VIN, service=service),
-                                      data_file='G31_NBTevo/RLF_INITIAL_RESPONSE.json')
+        remote_services._POLLING_CYCLE = 0
 
-        with mock.patch('bimmer_connected.account.requests', new=backend_mock):
-            account = ConnectedDriveAccount(TEST_USERNAME, TEST_PASSWORD, TEST_COUNTRY)
-            vehicle = account.get_vehicle(G31_VIN)
+        services = [
+            ('RLF', 'trigger_remote_light_flash'),
+            ('RDL', 'trigger_remote_door_lock'),
+            ('RDU', 'trigger_remote_door_unlock'),
+        ]
 
-            response = vehicle.remote_services.trigger_remote_light_flash()
-            self.assertEqual(ExecutionState.PENDING, response.state)
-            self.assertIn('/RLF', backend_mock.last_request.url)
+        for service, call in services:
+            backend_mock = BackendMock()
 
-            response = vehicle.remote_services.trigger_remote_door_lock()
-            self.assertEqual(ExecutionState.PENDING, response.state)
-            self.assertIn('/RDL', backend_mock.last_request.url)
+            with mock.patch('bimmer_connected.account.requests', new=backend_mock):
+                backend_mock.add_response(r'.*/api/vehicle/remoteservices/v1/{vin}/{service}'.format(
+                    vin=G31_VIN, service=service), data_files=['G31_NBTevo/RLF_INITIAL_RESPONSE.json'])
 
-            response = vehicle.remote_services.trigger_remote_door_unlock()
-            self.assertEqual(ExecutionState.PENDING, response.state)
-            self.assertIn('/RDU', backend_mock.last_request.url)
+                backend_mock.add_response(
+                    '.*/api/vehicle/remoteservices/v1/{vin}/state/execution'.format(vin=G31_VIN),
+                    data_files=[
+                        'G31_NBTevo/RLF_PENDING.json',
+                        'G31_NBTevo/RLF_DELIVERED.json',
+                        'G31_NBTevo/RLF_EXECUTED.json',
+                     ])
+
+                account = ConnectedDriveAccount(TEST_USERNAME, TEST_PASSWORD, TEST_COUNTRY)
+                vehicle = account.get_vehicle(G31_VIN)
+
+                response = getattr(vehicle.remote_services, call)()
+                self.assertEqual(ExecutionState.EXECUTED, response.state)
 
     def test_get_remote_service_status(self):
         """Test get_remove_service_status method."""
         backend_mock = BackendMock()
+
         with mock.patch('bimmer_connected.account.requests', new=backend_mock):
             account = ConnectedDriveAccount(TEST_USERNAME, TEST_PASSWORD, TEST_COUNTRY)
             vehicle = account.get_vehicle(G31_VIN)
             with self.assertRaises(IOError):
-                vehicle.remote_services.get_remote_service_status()
+                vehicle.remote_services._get_remote_service_status()
 
             backend_mock.add_response(
-                '-*/api/vehicle/remoteservices/v1/{vin}/state/execution'.format(vin=G31_VIN),
-                data_file='G31_NBTevo/RLF_EXECUTED.json')
-            status = vehicle.remote_services.get_remote_service_status()
+                '.*/api/vehicle/remoteservices/v1/{vin}/state/execution'.format(vin=G31_VIN),
+                data_files=['G31_NBTevo/RLF_EXECUTED.json'])
+            status = vehicle.remote_services._get_remote_service_status()
             self.assertEqual(ExecutionState.EXECUTED, status.state)

--- a/test/test_specs.py
+++ b/test/test_specs.py
@@ -22,7 +22,7 @@ class TestVehicleSpecs(unittest.TestCase):
         """Test with proper data."""
         backend_mock = BackendMock()
         backend_mock.add_response('.*/api/vehicle/specs/v1/{vin}'.format(vin=G31_VIN),
-                                  data_file='G31_NBTevo/specs.json')
+                                  data_files=['G31_NBTevo/specs.json'])
 
         with mock.patch('bimmer_connected.account.requests', new=backend_mock):
             account = ConnectedDriveAccount(TEST_USERNAME, TEST_PASSWORD, TEST_COUNTRY)

--- a/test/test_state.py
+++ b/test/test_state.py
@@ -60,7 +60,7 @@ class TestState(unittest.TestCase):
                 vehicle.state.update_data()
 
             backend_mock.add_response('.*/api/vehicle/dynamic/v1/{vin}'.format(vin=G31_VIN),
-                                      data_file='G31_NBTevo/dynamic.json')
+                                      data_files=['G31_NBTevo/dynamic.json'])
             vehicle.state.update_data()
             self.assertEqual(2201, vehicle.state.mileage)
 


### PR DESCRIPTION
After the comments on the PR in Home Assistant (https://github.com/home-assistant/home-assistant/pull/12591), here's a proposal to a new API for the remote services:

* The call to e.g. trigger_remote_door_lock now blocks until we get a final answer from the server. Note: this might take some time.
* If the vehicle state is expected to change after the call: an update of the vehicle state is triggered after a call to the remote services.
* The account now offers a listener to subscribe to vehicle state changes. This is necessary so that we can notify all listeners after an updated is triggered by a call to a remote service
* I incremented the version number, as this is a breaking API change.
* Added horn and climate control as remote services. :warning: I could not yet test these on a live vehicle. It's just implemented after the other examples...
* Update to unit tests to cover the changed code.
