### PR TITLE
Update basic_canada.py

### DIFF
--- a/basic_canada.py
+++ b/basic_canada.py
@@ -5,12 +5,19 @@ import urllib
 import argparse
 
 AUTHENTICATION_URL = 'https://b2vapi.bmwgroup.us/webapi/oauth/token'
-VEHICLES_URL = 'https://www.bmw-connecteddrive.de/api/me/vehicles/v2'
+VEHICLES_URL = 'https://b2vapi.bmwgroup.us/webapi/v1/user/vehicles'
 
 
 def get_token(username, password):
     headers = {
         "Content-Type": "application/x-www-form-urlencoded",
+        "Content-Length": "124",
+        "Connection": "Keep-Alive",
+        "Host": "b2vapi.bmwgroup.us",
+        "Accept-Encoding": "gzip",
+        "Authorization": "Basic blF2NkNxdHhKdVhXUDc0eGYzQ0p3VUVQOjF6REh4NnVuNGNEanliTEVOTjNreWZ1bVgya0VZaWdXUGNRcGR2RFJwSUJrN3JPSg==",
+        "Credentials": "nQv6CqtxJuXWP74xf3CJwUEP:1zDHx6un4cDjybLENN3kyfumX2kEYigWPcQpdvDRpIBk7rOJ",
+        "User-Agent": "okhttp/2.60",
     }
 
     # we really need all of these parameters
@@ -23,7 +30,7 @@ def get_token(username, password):
 
     data = urllib.parse.urlencode(values)
     response = requests.post(AUTHENTICATION_URL, data=data, headers=headers, allow_redirects=False)
-    if response.status_code != 302:
+    if response.status_code != 200:
         raise IOError('Unexpected status code: {}'.format(response.status_code))
     print('Response header:')
     print(response.headers)


### PR DESCRIPTION
I've added more information in the header, to match what the BMW Remote App is sending. The main thing that I think makes it work is the `"Authorization"` field. This string of numbers and letters seems to be hard coded into the BMW app, and if you don't send it the server will send a empty response. 

Also fixed the `VEHICLES_URL `and changed `response.status.code` to `200`, as the server sends a HTTP 200 code when the authentication is successful.

With these changes I can successfully get a response with the information of my car.

Contributes to #36 