### PR TITLE
made hostname in header configurable

### DIFF
--- a/bimmer_connected/account.py
+++ b/bimmer_connected/account.py
@@ -65,7 +65,7 @@ class ConnectedDriveAccount(object):  # pylint: disable=too-many-instance-attrib
                 "Content-Type": "application/x-www-form-urlencoded",
                 "Content-Length": "124",
                 "Connection": "Keep-Alive",
-                "Host": "b2vapi.bmwgroup.com",
+                "Host": self.server_url,
                 "Accept-Encoding": "gzip",
                 "Authorization": "Basic blF2NkNxdHhKdVhXUDc0eGYzQ0p3VUVQOjF6REh4NnVuNGNEanli"
                                  "TEVOTjNreWZ1bVgya0VZaWdXUGNRcGR2RFJwSUJrN3JPSg==",

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -45,7 +45,7 @@ class BackendMock(object):
 
     def __init__(self) -> None:
         """Constructor."""
-        self.last_request = None
+        self.last_request = []
         self.responses = [
             MockResponse('https://.+/webapi/oauth/token',
                          headers=_AUTH_RESPONSE_HEADERS,
@@ -57,12 +57,12 @@ class BackendMock(object):
 
     def get(self, url: str, headers: dict = None, data: str = None, allow_redirects: bool = None) -> 'MockResponse':
         """Mock for requests.get function."""
-        self.last_request = MockRequest(url, headers, data, request_type='GET', allow_redirects=allow_redirects)
+        self.last_request.append(MockRequest(url, headers, data, request_type='GET', allow_redirects=allow_redirects))
         return self._find_response(url)
 
     def post(self, url: str, headers: dict = None, data: str = None, allow_redirects: bool = None) -> 'MockResponse':
         """Mock for requests.post function."""
-        self.last_request = MockRequest(url, headers, data, request_type='GET', allow_redirects=allow_redirects)
+        self.last_request.append(MockRequest(url, headers, data, request_type='GET', allow_redirects=allow_redirects))
         return self._find_response(url)
 
     def add_response(self, regex: str, data: str = None, data_files: List[str] = None,

--- a/test/test_account.py
+++ b/test/test_account.py
@@ -34,3 +34,11 @@ class TestAccount(unittest.TestCase):
             account = ConnectedDriveAccount(TEST_USERNAME, TEST_PASSWORD, Regions.REST_OF_WORLD)
             with self.assertRaises(IOError):
                 account.send_request('invalid_url')
+
+    def test_us_header(self):
+        """Test if the host is set correctly in the request."""
+        backend_mock = BackendMock()
+        with mock.patch('bimmer_connected.account.requests', new=backend_mock):
+            ConnectedDriveAccount(TEST_USERNAME, TEST_PASSWORD, Regions.NORTH_AMERICA)
+            request = [r for r in backend_mock.last_request if 'oauth' in r.url][0]
+            self.assertEqual('b2vapi.bmwgroup.us', request.headers['Host'])


### PR DESCRIPTION
@lawtancool 
How about this solution for the issue in #45? We already have the server-url contain the string you wanted.

In Europe the `host` part of the header seems to be ignored. So `.us` works just as well as `.com`. Even no `host` works just as well...
