### PR TITLE
added function for check_control messagages, but data is not yet parsed

### DIFF
--- a/bimmer_connected/state.py
+++ b/bimmer_connected/state.py
@@ -316,6 +316,12 @@ class VehicleState(object):  # pylint: disable=too-many-public-methods
         """
         return self._attributes.get('checkControlMessages')
 
+    @property
+    @backend_parameter
+    def has_check_control_messages(self) -> bool:
+        """Return true if any check control message is present."""
+        return len(self.check_control_messages) > 0
+
 
 class Lid(object):  # pylint: disable=too-few-public-methods
     """A lid of the vehicle.

--- a/bimmer_connected/state.py
+++ b/bimmer_connected/state.py
@@ -306,6 +306,16 @@ class VehicleState(object):  # pylint: disable=too-many-public-methods
         """State of charge of the high voltage battery in percent."""
         return self._attributes.get('chargingLevelHv')
 
+    @property
+    @backend_parameter
+    def check_control_messages(self) -> List:
+        """List of check control messages.
+
+        Right now they are not parsed, as we do not have sample data with CC messages.
+        See issue https://github.com/ChristianKuehnel/bimmer_connected/issues/55
+        """
+        return self._attributes.get('checkControlMessages')
+
 
 class Lid(object):  # pylint: disable=too-few-public-methods
     """A lid of the vehicle.

--- a/bimmer_connected/vehicle.py
+++ b/bimmer_connected/vehicle.py
@@ -1,6 +1,7 @@
 """Models state and remote services of one vehicle."""
 from enum import Enum
 import logging
+from typing import List
 
 from bimmer_connected.state import VehicleState
 from bimmer_connected.remote_services import RemoteServices
@@ -14,6 +15,13 @@ class DriveTrainType(Enum):
     PHEV = 'PHEV'
     BEV = 'BEV'
     BEV_REX = 'BEV_REX'
+
+
+#: Set of drive trains that have a combustion engine
+COMBUSTION_ENGINE_DRIVE_TRAINS = {DriveTrainType.CONVENTIONAL, DriveTrainType.PHEV, DriveTrainType.BEV_REX}
+
+#: set of drive trains that have a high voltage battery
+HV_BATTERY_DRIVE_TRAINS = {DriveTrainType.PHEV, DriveTrainType.BEV, DriveTrainType.BEV_REX}
 
 
 class ConnectedDriveVehicle(object):
@@ -39,9 +47,42 @@ class ConnectedDriveVehicle(object):
         return DriveTrainType(self.attributes['driveTrain'])
 
     @property
-    def name(self):
+    def name(self) -> str:
         """Get the name of the vehicle."""
         return self.attributes['model']
+
+    @property
+    def has_hv_battery(self) -> bool:
+        """Return True if vehicle is equipped with a high voltage battery.
+
+        In this case we can get the state of the battery in the state attributes.
+        """
+        return self.drive_train in HV_BATTERY_DRIVE_TRAINS
+
+    @property
+    def has_internal_combustion_engine(self) -> bool:
+        """Return True if vehicle is equipped with an internal combustion engine.
+
+        In this case we can get the state of the gas tank."""
+        return self.drive_train in COMBUSTION_ENGINE_DRIVE_TRAINS
+
+    @property
+    def drive_train_attributes(self) -> List[str]:
+        """Get list of attributes available for the drive train of the vehicle.
+
+        The list of available attributes depends if on the type of drive train.
+        Some attributes only exist for electric/hybrid vehicles, others only if you
+        have a combustion engine. Depending on the state of the vehicle, some of
+        the attributes might still be None.
+        """
+        result = ['remaining_range_total']
+        if self.has_hv_battery:
+            result += ['charging_time_remaining', 'charging_status', 'max_range_electric', 'charging_level_hv']
+        if self.has_internal_combustion_engine:
+            result += ['remaining_fuel']
+        if self.has_hv_battery and self.has_internal_combustion_engine:
+            result += ['remaining_range_electric', 'remaining_range_fuel']
+        return result
 
     def __getattr__(self, item):
         """In the first version: just get the attributes from the dict.
@@ -51,6 +92,6 @@ class ConnectedDriveVehicle(object):
         """
         return self.attributes.get(item)
 
-    def __str__(self):
+    def __str__(self) -> str:
         """Use the name as identifier for the vehicle."""
         return '{}: {}'.format(self.__class__, self.name)

--- a/test/test_state.py
+++ b/test/test_state.py
@@ -3,8 +3,7 @@
 import unittest
 from unittest import mock
 import datetime
-from test import load_response_json, TEST_REGION, TEST_PASSWORD, TEST_USERNAME, BackendMock, G31_VIN, I01_VIN, \
-    I01_NOREX_VIN
+from test import load_response_json, TEST_REGION, TEST_PASSWORD, TEST_USERNAME, BackendMock, G31_VIN
 from bimmer_connected.account import ConnectedDriveAccount
 from bimmer_connected.state import VehicleState, LidState, LockState, ConditionBasedServiceStatus, \
     ParkingLightState, ChargingState
@@ -230,20 +229,11 @@ class TestState(unittest.TestCase):
                 self.assertGreater(state.remaining_range_total, 0)
                 self.assertIsNotNone(state.remaining_fuel)
                 self.assertIsNotNone(state.all_windows_closed)
-                self.assertEquals(0, len(state.check_control_messages))
+                self.assertEqual(0, len(state.check_control_messages))
                 self.assertFalse(state.has_check_control_messages)
 
-                electric_attributes = ['charging_status', 'charging_level_hv', 'charging_status', 'charging_level_hv']
-                self.check_attributes(electric_attributes, [I01_VIN, I01_NOREX_VIN], state, vehicle)
-
-                optional_electric_attriutes = ['charging_time_remaining']
-                self.check_attributes(optional_electric_attriutes, [I01_VIN], state, vehicle)
-
-    def check_attributes(self, attributes, vins, state, vehicle):
-        """Check if the state attributes are not None for all vehicles with a vin in vins."""
-        if vehicle.vin in vins:
-            for attrib in attributes:
-                self.assertIsNotNone(getattr(state, attrib), attrib)
-        else:
-            for attrib in attributes:
-                self.assertIsNone(getattr(state, attrib), attrib)
+                for attrib in vehicle.drive_train_attributes:
+                    print(attrib, getattr(state, attrib))
+                    # charging_time is only set when charging
+                    if attrib != 'charging_time_remaining':
+                        self.assertIsNotNone(getattr(state, attrib), attrib)

--- a/test/test_state.py
+++ b/test/test_state.py
@@ -230,6 +230,7 @@ class TestState(unittest.TestCase):
                 self.assertGreater(state.remaining_range_total, 0)
                 self.assertIsNotNone(state.remaining_fuel)
                 self.assertIsNotNone(state.all_windows_closed)
+                self.assertEquals(0, len(state.check_control_messages))
 
                 electric_attributes = ['charging_status', 'charging_level_hv', 'charging_status', 'charging_level_hv']
                 self.check_attributes(electric_attributes, [I01_VIN, I01_NOREX_VIN], state, vehicle)

--- a/test/test_state.py
+++ b/test/test_state.py
@@ -231,6 +231,7 @@ class TestState(unittest.TestCase):
                 self.assertIsNotNone(state.remaining_fuel)
                 self.assertIsNotNone(state.all_windows_closed)
                 self.assertEquals(0, len(state.check_control_messages))
+                self.assertFalse(state.has_check_control_messages)
 
                 electric_attributes = ['charging_status', 'charging_level_hv', 'charging_status', 'charging_level_hv']
                 self.check_attributes(electric_attributes, [I01_VIN, I01_NOREX_VIN], state, vehicle)

--- a/test/test_vehicle.py
+++ b/test/test_vehicle.py
@@ -1,7 +1,8 @@
 """Tests for ConnectedDriveVehicle."""
 import unittest
 from unittest import mock
-from test import load_response_json, BackendMock, TEST_USERNAME, TEST_PASSWORD, TEST_REGION
+from test import load_response_json, BackendMock, TEST_USERNAME, TEST_PASSWORD, TEST_REGION, \
+    G31_VIN, F48_VIN, I01_VIN, I01_NOREX_VIN, F15_VIN
 
 from bimmer_connected.vehicle import ConnectedDriveVehicle, DriveTrainType
 from bimmer_connected.account import ConnectedDriveAccount
@@ -26,5 +27,22 @@ class TestVehicle(unittest.TestCase):
             account = ConnectedDriveAccount(TEST_USERNAME, TEST_PASSWORD, TEST_REGION)
 
         for vehicle in account.vehicles:
+            print(vehicle.name)
             self.assertIsNotNone(vehicle.drive_train)
             self.assertIsNotNone(vehicle.name)
+            self.assertIsNotNone(vehicle.has_internal_combustion_engine)
+            self.assertIsNotNone(vehicle.has_hv_battery)
+            self.assertIsNotNone(vehicle.drive_train_attributes)
+
+    def test_drive_train_attributes(self):
+        """Test parsing different attributes of the vehicle."""
+        backend_mock = BackendMock()
+        with mock.patch('bimmer_connected.account.requests', new=backend_mock):
+            account = ConnectedDriveAccount(TEST_USERNAME, TEST_PASSWORD, TEST_REGION)
+
+        for vehicle in account.vehicles:
+            print(vehicle.name)
+            self.assertEqual(vehicle.vin in [G31_VIN, F48_VIN, F15_VIN, I01_VIN],
+                             vehicle.has_internal_combustion_engine)
+            self.assertEqual(vehicle.vin in [I01_VIN, I01_NOREX_VIN],
+                             vehicle.has_hv_battery)

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ max-line-length=120
 [testenv:flake8]
 base=python3
 ignore_errors=True
-commands=flake8
+commands=flake8 bimmer_connected test bimmerconnected
 
 [testenv:pylint]
 basepython = python3


### PR DESCRIPTION
**check control messages**
Added property `has_check_control_messages` to `VehicleState`. This should work without understanding the data from the check control messages. See also #55 

**drive train attributes**
I added the property  `drive_train_attributes` to the `ConnectedDriveVehicle` class. This way you can figure out which attributes exist in the state, depending on the type of the vehicle. This should come handy in #41.